### PR TITLE
GAMS Kestrel client synchronization for GAMS 44

### DIFF
--- a/gmske_nt.cmd
+++ b/gmske_nt.cmd
@@ -1,5 +1,5 @@
 @echo off
-set fileDir=%~dp0
+set fileDir=%~5
 set gmsPython=%fileDir%GMSPython\python.exe
 
 if exist "%gmsPython%" (


### PR DESCRIPTION
Synchronization of the GAMS Kestrel client as distributed with GAMS 44. This contains the following changes:
- Remove IBM docloud support
- Change gmoDataLoadLegacy from fillMatches=true to false
- Replace the use of Bonmin by SHOT
- Explicitly use 'certifi' certificate in Kestrel on Windows
- Add control file handling for version 51 and 52
- make email mandatory, read from env var NEOS_EMAIL, read from option file only in case optfile=1 is set
