### PR TITLE
GAMS Kestrel client synchronization for GAMS 47

### DIFF
--- a/gmske_us.run
+++ b/gmske_us.run
@@ -2,7 +2,7 @@
 gmsPython="${5}GMSPython/python"
 if [ -f "${gmsPython}" ]
 then
-    export SSL_CERT_FILE="${5}GMSPython/lib/python3.8/site-packages/certifi/cacert.pem"
+    export SSL_CERT_FILE="${5}GMSPython/lib/python3.12/site-packages/certifi/cacert.pem"
     "$gmsPython" "${5}gmske_ux.out" "$4"
 else
     python3 "${5}gmske_ux.out" "$4"


### PR DESCRIPTION
Synchronization of the GAMS Kestrel client as distributed with GAMS 47. This contains the following changes:
- The client-side implementation now strictly enforces TLS 1.2 or later.
- Added support for EMP models.
- Adjust Kestrel SSL certificate path to Python 3.12
- Add control file handling for version 53